### PR TITLE
sync for OpenBSD 6.3

### DIFF
--- a/pf/_struct.py
+++ b/pf/_struct.py
@@ -46,7 +46,7 @@ __all__ = ['timeval',
 # Constants
 IFNAMSIZ             = 16               # From /usr/include/net/if.h
 PFRES_MAX            = 17               # From /usr/include/net/pfvar.h
-LCNT_MAX             = 7                # From /usr/include/net/pfvar.h
+LCNT_MAX             = 10                # From /usr/include/net/pfvar.h
 FCNT_MAX             = 3                # From /usr/include/net/pfvar.h
 SCNT_MAX             = 3                # From /usr/include/net/pfvar.h
 PF_MD5_DIGEST_LENGTH = 16               # From /usr/include/net/pfvar.h
@@ -77,6 +77,7 @@ class pf_status(Structure):       # From /usr/include/net/pfvar.h
                 ("pcounters",         c_uint64 * 3 * 2 * 2),
                 ("bcounters",         c_uint64 * 2 * 2),
                 ("stateid",           c_uint64),
+                ("syncookies_inflight",c_uint64 * 2),
                 ("since",             c_int64),       # time_t
                 ("running",           c_uint32),
                 ("states",            c_uint32),
@@ -85,6 +86,9 @@ class pf_status(Structure):       # From /usr/include/net/pfvar.h
                 ("debug",             c_uint32),
                 ("hostid",            c_uint32),
                 ("reass",             c_uint32),
+                ("syncookies_active", c_uint8),
+                ("syncookies_mode",   c_uint8),
+                ("pad",               c_uint8 * 2),
                 ("ifname",            c_char * IFNAMSIZ),
                 ("pf_chksum",         c_uint8 * PF_MD5_DIGEST_LENGTH)]
 

--- a/pf/constants.py
+++ b/pf/constants.py
@@ -23,8 +23,7 @@ PF_AFRT                 = 15
 
 # PF transaction types (from /usr/include/net/pfvar.h)
 PF_TRANS_RULESET        = 0
-PF_TRANS_ALTQ           = 1
-PF_TRANS_TABLE          = 2
+PF_TRANS_TABLE          = 1
 
 # PF rule flags (from /usr/include/net/pfvar.h)
 PFRULE_DROP             = 0x0000

--- a/pf/status.py
+++ b/pf/status.py
@@ -31,6 +31,9 @@ class PFStatus(PFObject):
         self.ifname          = s.ifname
         self.running         = bool(s.running)
         self.stateid         = s.stateid
+        self.syncookies_inflight = s.syncookies_inflight
+        self.syncookies_active = s.syncookies_active
+        self.syncookies_mode = s.syncookies_mode
         self.since           = s.since
         self.states          = s.states
         self.states_halfopen = s.states_halfopen
@@ -64,7 +67,10 @@ class PFStatus(PFObject):
                           'max-src-conn':             s.lcounters[3],
                           'max-src-conn-rate':        s.lcounters[4],
                           'overload table insertion': s.lcounters[5],
-                          'overload flush states':    s.lcounters[6]}
+                          'overload flush states':    s.lcounters[6],
+                          'synfloods detected':       s.lcounters[7],
+                          'syncookies sent':          s.lcounters[8],
+                          'syncookies validated':     s.lcounters[9]}
 
         self.fcnt      = {'searches':                 s.fcounters[0],
                           'inserts':                  s.fcounters[1],


### PR DESCRIPTION
- sync `struct pf_status` changes for syncookies
- sync counters for syncookies
- remove deprecated `PF_TRANS_ALTQ while` here

As far as I could see these were the only changes in 6.3 that requires adjustment in py-pf. At least `get_status()` works again.
